### PR TITLE
Custom pass to make ASAN work

### DIFF
--- a/llvm_mode/compiler/angora_clang.c
+++ b/llvm_mode/compiler/angora_clang.c
@@ -111,6 +111,11 @@ static void add_angora_pass() {
   cc_params[cc_par_cnt++] = "-Xclang";
   cc_params[cc_par_cnt++] = alloc_printf("%s/pass/libAngoraPass.so", obj_path);
 
+  cc_params[cc_par_cnt++] = "-Xclang";
+  cc_params[cc_par_cnt++] = "-load";
+  cc_params[cc_par_cnt++] = "-Xclang";
+  cc_params[cc_par_cnt++] = alloc_printf("%s/pass/libSanitizeAddress.so", obj_path);
+
   if (clang_type == CLANG_DFSAN_TYPE) {
     cc_params[cc_par_cnt++] = "-mllvm";
     cc_params[cc_par_cnt++] = "-DFSanMode";

--- a/llvm_mode/pass/CMakeLists.txt
+++ b/llvm_mode/pass/CMakeLists.txt
@@ -53,3 +53,7 @@ install (TARGETS AngoraPass DESTINATION ${ANGORA_PASS_DIR})
 add_library(DFSanPass MODULE DFSanPass.cc)
 target_link_libraries(DFSanPass LLVMPassConfig)
 install (TARGETS DFSanPass DESTINATION ${ANGORA_PASS_DIR})
+
+add_library(SanitizeAddress MODULE SanitizeAddress.cc)
+target_link_libraries(SanitizeAddress LLVMPassConfig)
+install (TARGETS SanitizeAddress DESTINATION ${ANGORA_PASS_DIR})

--- a/llvm_mode/pass/SanitizeAddress.cc
+++ b/llvm_mode/pass/SanitizeAddress.cc
@@ -1,0 +1,33 @@
+#include "llvm/Pass.h"
+#include "llvm/IR/Function.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/Transforms/IPO/PassManagerBuilder.h"
+
+using namespace llvm;
+
+namespace {
+  class SanitizeAddress : public FunctionPass {
+  public:
+    static char ID;
+    SanitizeAddress() : FunctionPass(ID) {}
+
+    bool runOnFunction(Function &F) override {
+      F.addFnAttr(Attribute::SanitizeAddress);
+      return true;
+    }
+  };
+}
+
+static void registerSanitizeAddressPass(const PassManagerBuilder &, legacy::PassManagerBase &PM) {
+  PM.add(new SanitizeAddress());                                  
+}
+
+char SanitizeAddress::ID = 0;
+static RegisterPass<SanitizeAddress> X("sanitizeaddress", 
+                            "SanitizeAddress Pass");
+
+static RegisterStandardPasses 
+    RegisterParmesanLLVMPass(PassManagerBuilder::EP_CGSCCOptimizerLate,
+                              registerSanitizeAddressPass);


### PR DESCRIPTION
ASAN does not properly work because the SanitizeAddress function attribute does not get put on every function when compiling the bitcode from gclang to the fast binary. This pass tries to fix that by going over all functions and adding the attribute by hand. This needs to be altered a bit when other sanitizers need to be added, but it does its job for now.